### PR TITLE
scrubbing punctuation from run_info comments

### DIFF
--- a/R/integrity.R
+++ b/R/integrity.R
@@ -216,6 +216,7 @@ run_info <- function(fram_db, run_id) {
   cli::cli_h1('FRAM Run Information')
   cli::cli_text(cat(cli::col_blue('Species: '), cli::col_grey(run_info$species_name[[1]])))
   cli::cli_text(cat(cli::col_blue('Database Type: '), cli::col_grey(fram_db$fram_db_type)))
+  cli::cli_text(cat(cli::col_blue('Run ID: '), cli::col_grey(run_info$run_id[[1]])))
   cli::cli_text(cat(cli::col_blue('Run Name: '), cli::col_grey(run_info$run_name[[1]])))
   cli::cli_text(cat(cli::col_blue('Run Title: '), cli::col_grey(run_info$run_title[[1]])))
   cli::cli_text(cat(cli::col_blue('Run Date: '), cli::col_grey(run_info$run_time_date[[1]])))

--- a/R/integrity.R
+++ b/R/integrity.R
@@ -222,7 +222,7 @@ run_info <- function(fram_db, run_id) {
   cli::cli_text(cat(cli::col_blue('Modify Date: '), cli::col_grey(run_info$modify_input_date[[1]])))
   cli::cli_text(cat(cli::col_blue('TAMM: '), cli::col_grey(run_info$tamm_name[[1]])))
   cli::cli_text(cat(cli::col_blue('Coast Iterations: '), cli::col_grey(run_info$coastal_iterations[[1]])))
-  cli::cli_text(cat(cli::col_blue('Run Comments: '), '\n', cli::col_grey(run_info$run_comments[[1]])))
+  cli::cli_text(cat(cli::col_blue('Run Comments: '), '\n', cli::col_grey(stringr::str_remove_all(run_info$run_comments[[1]], "[[:punct:]]"))))
 
 }
 


### PR DESCRIPTION
Scrubbing punctuation from the comments field in `run_id()`.