### PR TITLE
added family cross-referencing for fishery filter functions

### DIFF
--- a/R/filters.R
+++ b/R/filters.R
@@ -5,7 +5,7 @@
 #' @param .data Dataframe containing `fishery_id` column. Commonly, output from `framrsquared::fetch_table()`.
 #' @param species Optional argument to identify species if `.data` doesn't already. If provided, must be "COHO" or "CHINOOK" or variations thereof. Defaults to `NULL`
 #' @export
-#' @seealso [filter_net()], [filter_puget_sound()], [filter_wa()], [filter_bc()], [filter_ak()], [filter_ca()], [filter_or()], #' [filter_coast()], [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_sport()
@@ -61,8 +61,7 @@ filter_sport <- function(.data, species = NULL) {
 #' @inheritParams filter_sport
 #'
 #' @export
-#' @seealso [filter_sport()], [filter_puget_sound()], [filter_wa()], [filter_bc()], [filter_ak()], [filter_ca()], [filter_or()],
-#' [filter_coast()], [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_net()
@@ -119,8 +118,7 @@ filter_net <- function(.data, species = NULL) {
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_wa()], [filter_bc()], [filter_ak()], [filter_ca()], [filter_or()],
-#' [filter_coast()], [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_puget_sound()
@@ -158,7 +156,7 @@ filter_puget_sound <- function(.data, species = NULL) {
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_puget_sound()], [filter_bc()], [filter_ak()], [filter_ca()], [filter_or()], #' [filter_coast()], [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_wa()
@@ -195,8 +193,7 @@ filter_wa <- function(.data, species = NULL) {
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_puget_sound()], [filter_ak()], [filter_wa()], [filter_ca()], [filter_or()],
-#' [filter_coast()], [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_bc()
@@ -233,8 +230,7 @@ filter_bc <- function(.data, species = NULL) {
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_puget_sound()], [filter_bc()], [filter_wa()], [filter_ca()], [filter_or()],
-#' [filter_coast()], [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_ak()
@@ -272,8 +268,7 @@ filter_ak <- function(.data, species = NULL) {
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_puget_sound()], [filter_ak()], [filter_bc()], [filter_wa()], [filter_or()],
-#' [filter_coast()], [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_ca()
@@ -310,8 +305,7 @@ filter_ca <- function(.data, species = NULL) {
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_puget_sound()], [filter_ak()], [filter_bc()], [filter_wa()], [filter_ca()],
-#' [filter_coast()], [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_or()
@@ -349,8 +343,7 @@ filter_or <- function(.data, species = NULL) {
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_puget_sound()], [filter_ak()], [filter_bc()], [filter_wa()], [filter_ca()], [filter_or()],
-#' [filter_marine()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_coast()
@@ -387,8 +380,7 @@ filter_coast <- function(.data, species = NULL) {
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_puget_sound()], [filter_ak()], [filter_bc()], [filter_wa()], [filter_ca()], [filter_or()],
-#' [filter_coast()], [filter_commercial_wa_nt()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_marine()
@@ -426,14 +418,14 @@ filter_marine <- function(.data, species = NULL) {
   }
 }
 
-#' Filters a dataframe to WA non-treaty commercial fisheries. Will
-#' automatically detect whether it's working with a Chinook or Coho
+#' Filters a dataframe to WA non-treaty commercial fisheries.
+#'
+#' Will automatically detect whether it's working with a Chinook or Coho
 #' dataset if the tables were generated within this package. `.data` must have
 #' a `fishery_id` column name.
 #' @inheritParams filter_sport
 #' @export
-#' @seealso [filter_sport()], [filter_net()], [filter_puget_sound()], [filter_ak()], [filter_bc()], [filter_wa()], [filter_ca()], [filter_or()],
-#' [filter_coast()], [filter_marine()]
+#' @family fishery_filters
 #' @examples
 #' \dontrun{
 #' fram_dataframe |> filter_commercial_wa_NT()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ framrsquared is part of the [FRAMverse R-Universe](https://framverse.r-universe.
 framrsquared can be installed through R-Universe:
 
 ``` r
-install.packages("framrsquared", repos = "https://framverse.r-universe.dev")
+install.packages(c("framrsquared", "framrosetta"), repos = "https://framverse.r-universe.dev")
 ```
 
 Otherwise, if you have Rtools and the `devtools` or `remotes` packages installed, framrsquared can be installed from source code:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -27,7 +27,7 @@ reference:
     desc: >
       Functions to filter FRAM tables by fishery
     contents:
-      - has_concept("fishery_filter")
+      - has_concept("fishery_filters")
   - title: "Comparing FRAM runs"
     desc: >
       Functions that compare two FRAM runs within the same database

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -27,7 +27,7 @@ reference:
     desc: >
       Functions to filter FRAM tables by fishery
     contents:
-      - starts_with("filter_")
+      - has_concept("fishery_filter")
   - title: "Comparing FRAM runs"
     desc: >
       Functions that compare two FRAM runs within the same database

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -126,6 +126,7 @@ reference:
     desc: >
         Miscellaneous functions
     contents:
+      - filter_flag
       - add_total_mortality
       - cohort_abundance
       - aeq_mortality

--- a/man/filter_ak.Rd
+++ b/man/filter_ak.Rd
@@ -28,6 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_ak(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_ak(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}},
-\code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_bc.Rd
+++ b/man/filter_bc.Rd
@@ -28,6 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_bc(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_bc(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}},
-\code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_ca.Rd
+++ b/man/filter_ca.Rd
@@ -28,6 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_ca(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_ca(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_or]{filter_or()}},
-\code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_coast.Rd
+++ b/man/filter_coast.Rd
@@ -28,6 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_coast(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_coast(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}},
-\code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_commercial_wa_nt.Rd
+++ b/man/filter_commercial_wa_nt.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/filters.R
 \name{filter_commercial_wa_nt}
 \alias{filter_commercial_wa_nt}
-\title{Filters a dataframe to WA non-treaty commercial fisheries. Will
-automatically detect whether it's working with a Chinook or Coho
-dataset if the tables were generated within this package. \code{.data} must have
-a \code{fishery_id} column name.}
+\title{Filters a dataframe to WA non-treaty commercial fisheries.}
 \usage{
 filter_commercial_wa_nt(.data, species = NULL)
 }
@@ -15,8 +12,7 @@ filter_commercial_wa_nt(.data, species = NULL)
 \item{species}{Optional argument to identify species if \code{.data} doesn't already. If provided, must be "COHO" or "CHINOOK" or variations thereof. Defaults to \code{NULL}}
 }
 \description{
-Filters a dataframe to WA non-treaty commercial fisheries. Will
-automatically detect whether it's working with a Chinook or Coho
+Will automatically detect whether it's working with a Chinook or Coho
 dataset if the tables were generated within this package. \code{.data} must have
 a \code{fishery_id} column name.
 }
@@ -28,6 +24,16 @@ framrosetta::fishery_chinook_fram |> filter_commercial_wa_nt(species = "CHINOOK"
 framrosetta::fishery_coho_fram |> filter_commercial_wa_nt(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}},
-\code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_marine.Rd
+++ b/man/filter_marine.Rd
@@ -28,6 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_marine(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_marine(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}},
-\code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_net.Rd
+++ b/man/filter_net.Rd
@@ -28,6 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_net(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_net(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}},
-\code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_or.Rd
+++ b/man/filter_or.Rd
@@ -28,6 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_or(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_or(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_ca]{filter_ca()}},
-\code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_puget_sound.Rd
+++ b/man/filter_puget_sound.Rd
@@ -28,6 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_puget_sound(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_puget_sound(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}},
-\code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_sport}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_sport.Rd
+++ b/man/filter_sport.Rd
@@ -29,5 +29,16 @@ framrosetta::fishery_coho_fram |> filter_sport(species = "COHO")
 
 }
 \seealso{
-\code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_wa]{filter_wa()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}}, #' \code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_wa}()}
 }
+\concept{fishery_filters}

--- a/man/filter_wa.Rd
+++ b/man/filter_wa.Rd
@@ -28,5 +28,16 @@ framrosetta::fishery_chinook_fram |> filter_wa(species = "CHINOOK")
 framrosetta::fishery_coho_fram |> filter_wa(species = "COHO")
 }
 \seealso{
-\code{\link[=filter_sport]{filter_sport()}}, \code{\link[=filter_net]{filter_net()}}, \code{\link[=filter_puget_sound]{filter_puget_sound()}}, \code{\link[=filter_bc]{filter_bc()}}, \code{\link[=filter_ak]{filter_ak()}}, \code{\link[=filter_ca]{filter_ca()}}, \code{\link[=filter_or]{filter_or()}}, #' \code{\link[=filter_coast]{filter_coast()}}, \code{\link[=filter_marine]{filter_marine()}}, \code{\link[=filter_commercial_wa_nt]{filter_commercial_wa_nt()}}
+Other fishery_filters: 
+\code{\link{filter_ak}()},
+\code{\link{filter_bc}()},
+\code{\link{filter_ca}()},
+\code{\link{filter_coast}()},
+\code{\link{filter_commercial_wa_nt}()},
+\code{\link{filter_marine}()},
+\code{\link{filter_net}()},
+\code{\link{filter_or}()},
+\code{\link{filter_puget_sound}()},
+\code{\link{filter_sport}()}
 }
+\concept{fishery_filters}


### PR DESCRIPTION
- Using @family in roxygen2 documentation to simultaneously (a) tag related functions, and (b) populate appropriate "see also" in the documentation. For now, `filter_fishery` as family label for the fishery filter functions
- Using `has_concept()` in pkgdown.yaml to group all `filter_fishery` functions together. This is better than using "starts_with", as it no longer picks up the `filter_flag()` validation function.