### PR TITLE
Update heatmaps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 - fixed bug in which `fetch_table()` errored out when fetching the `Stock` or `Fishery` tables.
 - added functions to handle SONCC calculations for STT.
 - updated `compare_runs()` to apply specified tolerance to recruits as well as fishery inputs
-- Overhauled `plot_impacts_per_catch_heatmap`: no longer includes non-retention, can control more aspects of the plots (rounding, font size, abbreviated or full stock name for title), fishery labels include id numbers and timestep labels include months. Can toggle between "landed catch per impacts" (default) and "impacts per thousand landed catch". 
+- Overhauled `plot_impacts_per_catch_heatmap`: no longer includes non-retention, can control more aspects of the plots (rounding, font size, abbreviated or full stock name for title), fishery labels include id numbers and timestep labels include months. Can toggle between "landed catch per impacts" (default) and "impacts per thousand landed catch". Function can now accept multiple stock ids, making it more useful for managing to objectives that are based on a sum of FRAM stocks.
+- improved speed of `stock_mortality()` and `fishery_mortality()`. Optionally accept either `stock_id` or `fishery_id` arguments which filter the fetched `mortality` function for improved speed. 
 
 # framrsquared 0.8.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # framrsquared (development version)
 
 - fixed bug in which `fetch_table()` errored out when fetching the `Stock` or `Fishery` tables.
+- added functions to handle SONCC calculations for STT.
+- updated `compare_runs()` to apply specified tolerance to recruits as well as fishery inputs
+- Overhauled `plot_impacts_per_catch_heatmap`: no longer includes non-retention, can control more aspects of the plots (rounding, font size, abbreviated or full stock name for title), fishery labels include id numbers and timestep labels include months. Can toggle between "landed catch per impacts" (default) and "impacts per thousand landed catch". 
 
 # framrsquared 0.8.1
 
@@ -16,7 +19,6 @@
 - `fetch_table()` and `aeq_mortality()` now default to adding labels for fisheries, stocks, and flags. This can be turned off with `label = FALSE`. DEV NOTE: `fetch_table()_` is a non-exported alias for `fetch_table()` with `label = FALSE`, ditto `aeq_mortality_()` for `aeq_mortality()`.
 - `add_total_mortality()` inserts a `total_mortalities` column into a mortality database, which is the sum of the eight mortality columns. Also works on the output of `aeq_mortality()`. This is now used under the hood in several framrsquared functions like `stock_fate_*()`.
 - For developers: non-exported function `check_demo_coverage()` takes path to a NAMESPACE file and a document file (like the `framrsquared_test_and_demo.qmd` file) and checks if each of the exported files from the package are present in the document. Useful for double-checking a complete tesitng file. 
-
 
 
 ## Bug fixes and minor improvements

--- a/R/make_impacts_per_catch_heatmap.R
+++ b/R/make_impacts_per_catch_heatmap.R
@@ -1,7 +1,7 @@
 #' Make plots to show the amount of landed catch_per_impact
 #'
 #' Identify how much reduction in landed catch at each fishery that would be needed
-#' to reduce the impacts on a focal stock by 1 fish.
+  #' to reduce the impacts on a focal stock by 1 fish. Does not include non-retention moralities, as those can't be improved by reducing fishing in the focal species.
 #'
 #' @param fram_db fram database connection
 #' @param run_id run_id of interest
@@ -12,6 +12,7 @@
 #' @param outer_text_size Controls size of plot text elements except cell text. Different plot elements scale relative to this value. Numeric defaults to 18.
 #' @param cell_text_size Controls size of text size in heatmap cells.  Numeric, defaults to 5. Different units from `outer_text_size`.
 #' @param short_title Should the abbreviated stock name (e.g., "M-ssdnph") be used (`TRUE`) or the longer name (e.g., "South Puget SOund Net Pens Marked"). Logical, defaults to `FALSE`; `TRUE` may be useful when plots must be small.
+#' @param per_thousand_catch Should plot be presented in units of Impacts per Thousand Landed Catch (TRUE) or landed catch per impact (FALSE). Logical, defaults to FALSE.
 #' @return ggplot object
 #' @export
 #'
@@ -85,14 +86,6 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
     )
   }
 
-
-  fishery_landed <- fishery_mortality(fram_db, run_id = run_id) |>
-    dplyr::group_by(.data$fishery_id, .data$time_step) |>
-    dplyr::summarize(landed_catch = sum(.data$landed_catch))
-
-
-  ## for chinook
-
   if (fram_db$fram_db_species == "CHINOOK") {
     stock_mort = aeq_mortality_(fram_db, run_id = run_id, msp = msp) |>
       dplyr::filter(stock_id %in% .env$stock_id) |>
@@ -102,7 +95,7 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
       dplyr::summarize(mort = sum(.data$total_mortality)) |>
       dplyr::ungroup()
   } else{
-    stock_mort = stock_mortality(fram_db, run_id = run_id) |>
+    stock_mort = stock_mortality(fram_db, run_id = run_id, stock_id = stock_id) |>
       ## stock mortality combines msf and NS values.
       dplyr::mutate(total_mortality = .data$landed_catch + .data$shaker + .data$drop_off) |>
       dplyr::filter(stock_id %in% .env$stock_id) |>
@@ -110,6 +103,26 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
       dplyr::summarize(mort = sum(.data$total_mortality)) |>
       dplyr::ungroup()
   }
+  attr(stock_mort, "species") <- fram_db$fram_db_species
+
+  if(!is.null(filters_list)){
+    ## give species for filtering
+    for(i in 1:length(filters_list)){
+      stock_mort <- stock_mort |>
+        filters_list[[i]]()
+    }
+  }
+
+
+
+  fishery_landed <- fishery_mortality(fram_db, run_id = run_id, fishery_id = unique(stock_mort$fishery_id)) |>
+    dplyr::group_by(.data$fishery_id, .data$time_step) |>
+    dplyr::summarize(landed_catch = sum(.data$landed_catch))
+
+
+  ## for chinook
+
+
 
   time_step_lut <- fram_db |>
     fetch_table_(table_name = "TimeStep") |>
@@ -129,13 +142,7 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
   attr(dat_plot, "species") <- fram_db$fram_db_species
 
 
-  if(!is.null(filters_list)){
-    ## give species for filtering
-    for(i in 1:length(filters_list)){
-      dat_plot <- dat_plot |>
-        filters_list[[i]]()
-    }
-  }
+
   dat_plot <- dat_plot |>
     framrosetta::label_fisheries() |>
     dplyr::mutate(fishery_label = glue::glue("{fishery_label} | (id={fishery_id})")) |>
@@ -144,13 +151,13 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
     tidyr::complete(.data$fishery_label, .data$timestep_label)
 
   fishery_label_sorted <- dat_plot |>
-    dplyr::arrange(fishery_id) |>
-    dplyr::pull(fishery_label) |>
+    dplyr::arrange(.data$fishery_id) |>
+    dplyr::pull(.data$fishery_label) |>
     unique() |>
     rev()
 
   dat_plot <-  dat_plot |>
-    dplyr::mutate(fishery_label = factor(fishery_label, levels = fishery_label_sorted))
+    dplyr::mutate(fishery_label = factor(.data$fishery_label, levels = fishery_label_sorted))
 
   if(per_thousand_catch){
     cli::cli_alert("Plotting in units of impacts per thousand catch.")

--- a/R/make_impacts_per_catch_heatmap.R
+++ b/R/make_impacts_per_catch_heatmap.R
@@ -5,9 +5,13 @@
 #'
 #' @param fram_db fram database connection
 #' @param run_id run_id of interest
-#' @param stock_id stock_id of interest
+#' @param stock_id stock_id of interest. Can accept multiple stock_ids, and will plot the impact on the combined stocks.
 #' @param filters_list list of framrsquared filter functions to apply before plotting. Defaults to `list(filter_wa, filter_sport)`, which filters to WA sport fisheries.
-#' @param msp  Use Model Stock Proportion? Logical, defaults to TRUE.
+#' @param msp  Use Model Stock Proportion? Logical, defaults to TRUE. Only relevant for Chinook databases.
+#' @param digits_round How many digits should cell values be rounded to? Numeric, defaults to 1.
+#' @param outer_text_size Controls size of plot text elements except cell text. Different plot elements scale relative to this value. Numeric defaults to 18.
+#' @param cell_text_size Controls size of text size in heatmap cells.  Numeric, defaults to 5. Different units from `outer_text_size`.
+#' @param short_title Should the abbreviated stock name (e.g., "M-ssdnph") be used (`TRUE`) or the longer name (e.g., "South Puget SOund Net Pens Marked"). Logical, defaults to `FALSE`; `TRUE` may be useful when plots must be small.
 #' @return ggplot object
 #' @export
 #'
@@ -40,18 +44,18 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
   validate_numeric(cell_text_size, n = 1)
   validate_flag(short_title)
   validate_flag(per_thousand_catch)
-#
-#   if(is.null(digits_round)){
-#     if(per_thousand_catch){
-#       digits_round = 5
-#     } else {
-#       digits_round = 1
-#     }
-#   }
+  #
+  #   if(is.null(digits_round)){
+  #     if(per_thousand_catch){
+  #       digits_round = 5
+  #     } else {
+  #       digits_round = 1
+  #     }
+  #   }
 
   validate_stock_ids(fram_db, stock_id)
   if(length(stock_id)>1){
-    cli::cli_abort("`stock_id` must be single stock.")
+    cli::cli_alert_warning("Multiple stock IDs provided! Interpret combined impacts with caution!")
   }
 
   validate_flag(msp)
@@ -67,10 +71,10 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
 
   stock_table <- fetch_table_(fram_db, "Stock")
   stock_name <- stock_table |>
-    dplyr::filter(stock_id == .env$stock_id) |>
+    dplyr::filter(stock_id %in% .env$stock_id) |>
     dplyr::pull(.data$stock_name)
   stock_title <- stock_table |>
-    dplyr::filter(stock_id == .env$stock_id) |>
+    dplyr::filter(stock_id %in% .env$stock_id) |>
     dplyr::pull(.data$stock_long_name)
 
   if (length(stock_name) == 0) {
@@ -91,7 +95,7 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
 
   if (fram_db$fram_db_species == "CHINOOK") {
     stock_mort = aeq_mortality_(fram_db, run_id = run_id, msp = msp) |>
-      dplyr::filter(stock_id == .env$stock_id) |>
+      dplyr::filter(stock_id %in% .env$stock_id) |>
       dplyr::mutate(total_mortality = .data$landed_catch + .data$shaker + .data$drop_off +
                       .data$msf_landed_catch + .data$msf_shaker + .data$msf_drop_off) |>
       dplyr::group_by(.data$fishery_id, .data$time_step) |>
@@ -101,7 +105,7 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
     stock_mort = stock_mortality(fram_db, run_id = run_id) |>
       ## stock mortality combines msf and NS values.
       dplyr::mutate(total_mortality = .data$landed_catch + .data$shaker + .data$drop_off) |>
-      dplyr::filter(stock_id == .env$stock_id) |>
+      dplyr::filter(stock_id %in% .env$stock_id) |>
       dplyr::group_by(.data$fishery_id, .data$time_step) |>
       dplyr::summarize(mort = sum(.data$total_mortality)) |>
       dplyr::ungroup()
@@ -139,6 +143,15 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
     dplyr::filter(.data$catch_per_impact != 0) |>
     tidyr::complete(.data$fishery_label, .data$timestep_label)
 
+  fishery_label_sorted <- dat_plot |>
+    dplyr::arrange(fishery_id) |>
+    dplyr::pull(fishery_label) |>
+    unique() |>
+    rev()
+
+  dat_plot <-  dat_plot |>
+    dplyr::mutate(fishery_label = factor(fishery_label, levels = fishery_label_sorted))
+
   if(per_thousand_catch){
     cli::cli_alert("Plotting in units of impacts per thousand catch.")
 
@@ -146,15 +159,19 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
 
     subtitle = "Impacts per 1000 landed catch."
     fill_label = "Impacts / 1k\n"
+    legend_scale_labels = c("Lowest\nImpact", "Highest\nImpact")
 
 
     color_low = "aquamarine"
     color_high = "goldenrod1"
+
+
   } else {
     cli::cli_alert("Plotting in units of landed catch per impact.")
 
     subtitle = "Landed catch per impact."
     fill_label = "catch per\nimpact"
+    legend_scale_labels = c("Highest\nImpact", "Lowest\nImpact")
 
     color_low = "goldenrod1"
     color_high = "aquamarine"
@@ -163,11 +180,25 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
   # dat_plot <- dat_plot |>
   #   dplyr::mutate(catch_per_impact = round(catch_per_impact, digits_round))
 
-  if(short_title){
-    plot_title = glue::glue("{stock_name} (stock_id = {stock_id})")
+
+  if(length(stock_id)>1)
+  {
+    plot_title = glue::glue("Combined Stocks {glue::glue_collapse(stock_id, ', ')}: {glue::glue_collapse(stock_name, ', ')}")
   } else {
-    plot_title = glue::glue("{stock_title} (stock_id = {stock_id})")
+    if(short_title){
+      plot_title = glue::glue("{stock_name} (stock_id = {stock_id})")
+    } else {
+      plot_title = glue::glue("{stock_title} (stock_id = {stock_id})")
+    }
   }
+
+  ## placement of qualitative legend scale labels
+  scale_range = range(dat_plot$catch_per_impact, na.rm = T)
+  ## positioning equally on log scale
+  scale_range = exp(log(scale_range) + c(1, -1) * 0.1 * diff(log(scale_range)))
+
+
+
 
   ggplot2::ggplot(
     dat_plot,
@@ -189,9 +220,12 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
       low = color_low,
       high = color_high,
       trans = "log",
-      labels = function(x) {
-        format(signif(x, 1), big.mark = ",")
-      }
+      breaks = scale_range,
+      # labels = legend_scale_labels
+      labels = c("Lowest", "Highest")
+      # labels = function(x) {
+      #   format(signif(x, 1), big.mark = ",")
+      # }
     ) +
     ggplot2::coord_flip() +
     ggplot2::labs(

--- a/R/make_impacts_per_catch_heatmap.R
+++ b/R/make_impacts_per_catch_heatmap.R
@@ -22,10 +22,32 @@
 #'                                run_id = 132,
 #'                                stock_id = 5)
 #' }
-plot_impacts_per_catch_heatmap <- function(fram_db, run_id, stock_id, filters_list = list(filter_wa, filter_sport), msp = TRUE) {
+plot_impacts_per_catch_heatmap <- function(fram_db,
+                                           run_id,
+                                           stock_id,
+                                           filters_list = list(filter_wa, filter_sport),
+                                           msp = TRUE,
+                                           digits_round = 1,
+                                           outer_text_size = 18,
+                                           cell_text_size = 5,
+                                           short_title = FALSE,
+                                           per_thousand_catch = FALSE) {
   validate_fram_db(fram_db)
   validate_run_id(fram_db, run_id)
   validate_stock_ids(fram_db, stock_id)
+  validate_numeric(digits_round, n = 1)
+  validate_numeric(outer_text_size, n = 1)
+  validate_numeric(cell_text_size, n = 1)
+  validate_flag(short_title)
+  validate_flag(per_thousand_catch)
+#
+#   if(is.null(digits_round)){
+#     if(per_thousand_catch){
+#       digits_round = 5
+#     } else {
+#       digits_round = 1
+#     }
+#   }
 
   validate_stock_ids(fram_db, stock_id)
   if(length(stock_id)>1){
@@ -47,6 +69,9 @@ plot_impacts_per_catch_heatmap <- function(fram_db, run_id, stock_id, filters_li
   stock_name <- stock_table |>
     dplyr::filter(stock_id == .env$stock_id) |>
     dplyr::pull(.data$stock_name)
+  stock_title <- stock_table |>
+    dplyr::filter(stock_id == .env$stock_id) |>
+    dplyr::pull(.data$stock_long_name)
 
   if (length(stock_name) == 0) {
     cli::cli_abort(
@@ -67,22 +92,36 @@ plot_impacts_per_catch_heatmap <- function(fram_db, run_id, stock_id, filters_li
   if (fram_db$fram_db_species == "CHINOOK") {
     stock_mort = aeq_mortality_(fram_db, run_id = run_id, msp = msp) |>
       dplyr::filter(stock_id == .env$stock_id) |>
-      add_total_mortality() |>
+      dplyr::mutate(total_mortality = .data$landed_catch + .data$shaker + .data$drop_off +
+                      .data$msf_landed_catch + .data$msf_shaker + .data$msf_drop_off) |>
       dplyr::group_by(.data$fishery_id, .data$time_step) |>
       dplyr::summarize(mort = sum(.data$total_mortality)) |>
       dplyr::ungroup()
   } else{
     stock_mort = stock_mortality(fram_db, run_id = run_id) |>
-      dplyr::mutate(total_mortality = .data$landed_catch + .data$non_retention + .data$shaker + .data$drop_off) |>
+      ## stock mortality combines msf and NS values.
+      dplyr::mutate(total_mortality = .data$landed_catch + .data$shaker + .data$drop_off) |>
       dplyr::filter(stock_id == .env$stock_id) |>
       dplyr::group_by(.data$fishery_id, .data$time_step) |>
       dplyr::summarize(mort = sum(.data$total_mortality)) |>
       dplyr::ungroup()
   }
 
+  time_step_lut <- fram_db |>
+    fetch_table_(table_name = "TimeStep") |>
+    dplyr::filter(.data$species == fram_db$fram_db_species) |>
+    dplyr::select("time_step_id", "time_step_name") |>
+    dplyr::rename(time_step = "time_step_id")
+
   dat_plot <- dplyr::full_join(fishery_landed, stock_mort, by = c("fishery_id", "time_step")) |>
     dplyr::mutate(catch_per_impact = .data$landed_catch / .data$mort) |>
-    tibble::as_tibble()
+    dplyr::mutate(catch_per_impact = dplyr::if_else(
+      is.infinite(.data$catch_per_impact),
+      NA,
+      .data$catch_per_impact)) |>
+    tibble::as_tibble() |>
+    dplyr::left_join(time_step_lut, by = "time_step") |>
+    dplyr::mutate(timestep_label = glue::glue("{time_step}\n({time_step_name})"))
   attr(dat_plot, "species") <- fram_db$fram_db_species
 
 
@@ -95,29 +134,60 @@ plot_impacts_per_catch_heatmap <- function(fram_db, run_id, stock_id, filters_li
   }
   dat_plot <- dat_plot |>
     framrosetta::label_fisheries() |>
+    dplyr::mutate(fishery_label = glue::glue("{fishery_label} | (id={fishery_id})")) |>
     dplyr::filter(!is.na(.data$catch_per_impact)) |>
     dplyr::filter(.data$catch_per_impact != 0) |>
-    tidyr::complete(.data$fishery_label, .data$time_step)
+    tidyr::complete(.data$fishery_label, .data$timestep_label)
+
+  if(per_thousand_catch){
+    cli::cli_alert("Plotting in units of impacts per thousand catch.")
+
+    dat_plot$catch_per_impact = 1/dat_plot$catch_per_impact * 1000
+
+    subtitle = "Impacts per 1000 landed catch."
+    fill_label = "Impacts / 1k\n"
+
+
+    color_low = "aquamarine"
+    color_high = "goldenrod1"
+  } else {
+    cli::cli_alert("Plotting in units of landed catch per impact.")
+
+    subtitle = "Landed catch per impact."
+    fill_label = "catch per\nimpact"
+
+    color_low = "goldenrod1"
+    color_high = "aquamarine"
+  }
+  #
+  # dat_plot <- dat_plot |>
+  #   dplyr::mutate(catch_per_impact = round(catch_per_impact, digits_round))
+
+  if(short_title){
+    plot_title = glue::glue("{stock_name} (stock_id = {stock_id})")
+  } else {
+    plot_title = glue::glue("{stock_title} (stock_id = {stock_id})")
+  }
 
   ggplot2::ggplot(
     dat_plot,
     ggplot2::aes(
       x = .data$fishery_label,
-      y = .data$time_step,
+      y = .data$timestep_label,
       fill = .data$catch_per_impact,
       label = dplyr::if_else(
         is.na(.data$catch_per_impact),
         "",
-        format(round(.data$catch_per_impact, 1), big.mark = ",")
+        format(round(.data$catch_per_impact, digits_round), big.mark = ",")
       )
     )
   ) +
     ggplot2::geom_tile() +
-    ggplot2::geom_text() +
-    ggplot2::scale_y_continuous(position = "right") +
+    ggplot2::geom_text(size = cell_text_size) +
+    ggplot2::scale_y_discrete(position = "right") +
     ggplot2::scale_fill_gradient(
-      low = "goldenrod1",
-      high = "aquamarine",
+      low = color_low,
+      high = color_high,
       trans = "log",
       labels = function(x) {
         format(signif(x, 1), big.mark = ",")
@@ -126,13 +196,13 @@ plot_impacts_per_catch_heatmap <- function(fram_db, run_id, stock_id, filters_li
     ggplot2::coord_flip() +
     ggplot2::labs(
       y = "Timestep",
-      title = glue::glue("{stock_name} (stock_id = {stock_id})"),
-      subtitle = glue::glue("Landed catch per impact"),
-      fill = "catch per\nimpact",
+      title = plot_title,
+      subtitle = subtitle,
+      fill = fill_label,
       x = ""
     ) +
     ggplot2::theme(
-      text = ggplot2::element_text(size = 18),
+      text = ggplot2::element_text(size = outer_text_size),
       panel.background = ggplot2::element_blank()
     )
 }

--- a/R/report_fishery_mortality.R
+++ b/R/report_fishery_mortality.R
@@ -7,9 +7,10 @@
 #' \dontrun{
 #' fram_db |> fishery_mortality(run_id = 101)
 #' }
-fishery_mortality <- function(fram_db, run_id = NULL, msp = TRUE) {
+fishery_mortality <- function(fram_db, run_id = NULL, fishery_id = NULL, msp = TRUE) {
   validate_fram_db(fram_db)
   if(!is.null(run_id)){validate_run_id(fram_db, run_id)}
+  if(!is.null(fishery_id)){validate_fishery_ids(fram_db, fishery_id)}
   validate_flag(msp)
 
   fishery_mort <- fram_db |>
@@ -18,6 +19,10 @@ fishery_mortality <- function(fram_db, run_id = NULL, msp = TRUE) {
   if(!is.null(run_id)){
     fishery_mort <- fishery_mort |>
       dplyr::filter(.data$run_id %in% .env$run_id)
+  }
+  if(!is.null(fishery_id)){
+    fishery_mort <- fishery_mort |>
+      dplyr::filter(.data$fishery_id %in% .env$fishery_id)
   }
 
   fishery_mort <- fishery_mort |>

--- a/R/report_fishery_mortality.R
+++ b/R/report_fishery_mortality.R
@@ -1,6 +1,7 @@
 #' Returns a tibble matching the Fishery Mortality screen.
 #' @param fram_db FRAM database object
-#' @param run_id Run ID
+#' @param run_id atomic or vector of run_ids to filter to. Can improve speed. Optional, defaults to `NULL`.
+#' @param fishery_id atomic or vector of fishery_id to filter to. Can improve speed. Optional, defaults to `NULL`.
 #' @param msp Use Model Stock Proportion? Logical, defaults to TRUE.
 #' @export
 #' @examples
@@ -93,7 +94,8 @@ fishery_mortality <- function(fram_db, run_id = NULL, fishery_id = NULL, msp = T
 #' }
 #'
 
-plot_stock_mortality <- function(fram_db, run_id, stock_id, top_n = 10, filters_list = NULL, msp = TRUE){
+plot_stock_mortality <- function(fram_db, run_id, stock_id,
+                                 top_n = 10, filters_list = NULL, msp = TRUE){
   validate_fram_db(fram_db)
   validate_run_id(fram_db, run_id)
   validate_stock_ids(fram_db, stock_id)

--- a/R/report_fishery_mortality.R
+++ b/R/report_fishery_mortality.R
@@ -9,17 +9,24 @@
 #' }
 fishery_mortality <- function(fram_db, run_id = NULL, msp = TRUE) {
   validate_fram_db(fram_db)
-  if(!is.numeric(run_id)){validate_run_id(fram_db, run_id)}
+  if(!is.null(run_id)){validate_run_id(fram_db, run_id)}
   validate_flag(msp)
 
   fishery_mort <- fram_db |>
-    fetch_table_("Mortality") |>
+    fetch_table_("Mortality")
+
+  if(!is.null(run_id)){
+    fishery_mort <- fishery_mort |>
+      dplyr::filter(.data$run_id %in% .env$run_id)
+  }
+
+  fishery_mort <- fishery_mort |>
     dplyr::group_by(
-      .data$run_id,
-      .data$age,
-      .data$fishery_id,
-      .data$time_step
-    ) |>
+    .data$run_id,
+    .data$age,
+    .data$fishery_id,
+    .data$time_step
+  ) |>
     dplyr::summarize(
       dplyr::across(
         c(
@@ -48,14 +55,8 @@ fishery_mortality <- function(fram_db, run_id = NULL, msp = TRUE) {
     dplyr::arrange(.data$run_id, .data$fishery_id, .data$age, .data$time_step)
 
 
-  if (is.null(run_id)) {
-    fishery_mort |> # returns fishery mortality for all runs in db
-      `attr<-`('species', fram_db$fram_db_species)
-  } else {
-    fishery_mort |>
-      dplyr::filter(.data$run_id %in% .env$run_id) |>
-      `attr<-`('species', fram_db$fram_db_species)
-  }
+  attr(fishery_mort, 'species') <- fram_db$fram_db_species
+  return(fishery_mort)
 
 
 }

--- a/R/report_stock_mortality.R
+++ b/R/report_stock_mortality.R
@@ -20,7 +20,14 @@ stock_mortality <- function(fram_db, run_id = NULL) {
   }
 
   stock_mort <- fram_db |>
-    fetch_table_("Mortality") |>
+    fetch_table_("Mortality")
+
+  if(!is.null(run_id)){
+    stock_mort <- stock_mort |>
+      dplyr::filter(.data$run_id %in% .env$run_id)
+  }
+
+  stock_mort <- stock_mort |>
     dplyr::group_by(
       .data$run_id,
       .data$age,
@@ -56,14 +63,9 @@ stock_mortality <- function(fram_db, run_id = NULL) {
     ) |>
     dplyr::arrange(.data$run_id, .data$fishery_id, .data$age, .data$time_step)
 
-  if (is.null(run_id)) {
-    stock_mort |> # returns fishery mortality for all runs in db
-      `attr<-`('species', fram_db$fram_db_species)
-  } else {
-    stock_mort |>
-      dplyr::filter(.data$run_id %in% .env$run_id) |>
-      `attr<-`('species', fram_db$fram_db_species)
-  }
+  attr(stock_mort, 'species') <-  fram_db$fram_db_species
+
+  return(stock_mort)
 
 
 }

--- a/R/report_stock_mortality.R
+++ b/R/report_stock_mortality.R
@@ -3,7 +3,8 @@
 #' Returns a tibble matching the Stock Mortality screen.
 #'
 #' @param fram_db FRAM database object
-#' @param run_id Run ID
+#' @param run_id atomic or vector of run_ids to filter to. Can improve speed. Optional, defaults to `NULL`.
+#' @param stock_id atomic or vector of stock_id to filter to. Can improve speed. Optional, defaults to `NULL`.
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/report_stock_mortality.R
+++ b/R/report_stock_mortality.R
@@ -12,11 +12,14 @@
 #'  filter(stock_id == 17, fishery_id == 36)
 #'
 #' }
-stock_mortality <- function(fram_db, run_id = NULL) {
+stock_mortality <- function(fram_db, run_id = NULL, stock_id = NULL) {
 
   validate_fram_db(fram_db)
   if(!is.null(run_id)){
     validate_run_id(fram_db, run_id)
+  }
+  if(!is.null(stock_id)){
+    validate_stock_ids(fram_db, stock_id)
   }
 
   stock_mort <- fram_db |>
@@ -26,6 +29,11 @@ stock_mortality <- function(fram_db, run_id = NULL) {
     stock_mort <- stock_mort |>
       dplyr::filter(.data$run_id %in% .env$run_id)
   }
+  if(!is.null(stock_id)){
+    stock_mort <- stock_mort |>
+      dplyr::filter(.data$stock_id %in% .env$stock_id)
+  }
+
 
   stock_mort <- stock_mort |>
     dplyr::group_by(

--- a/man/fishery_mortality.Rd
+++ b/man/fishery_mortality.Rd
@@ -4,12 +4,14 @@
 \alias{fishery_mortality}
 \title{Returns a tibble matching the Fishery Mortality screen.}
 \usage{
-fishery_mortality(fram_db, run_id = NULL, msp = TRUE)
+fishery_mortality(fram_db, run_id = NULL, fishery_id = NULL, msp = TRUE)
 }
 \arguments{
 \item{fram_db}{FRAM database object}
 
-\item{run_id}{Run ID}
+\item{run_id}{atomic or vector of run_ids to filter to. Can improve speed. Optional, defaults to \code{NULL}.}
+
+\item{fishery_id}{atomic or vector of fishery_id to filter to. Can improve speed. Optional, defaults to \code{NULL}.}
 
 \item{msp}{Use Model Stock Proportion? Logical, defaults to TRUE.}
 }

--- a/man/plot_impacts_per_catch_heatmap.Rd
+++ b/man/plot_impacts_per_catch_heatmap.Rd
@@ -9,7 +9,12 @@ plot_impacts_per_catch_heatmap(
   run_id,
   stock_id,
   filters_list = list(filter_wa, filter_sport),
-  msp = TRUE
+  msp = TRUE,
+  digits_round = 1,
+  outer_text_size = 18,
+  cell_text_size = 5,
+  short_title = FALSE,
+  per_thousand_catch = FALSE
 )
 }
 \arguments{
@@ -17,18 +22,28 @@ plot_impacts_per_catch_heatmap(
 
 \item{run_id}{run_id of interest}
 
-\item{stock_id}{stock_id of interest}
+\item{stock_id}{stock_id of interest. Can accept multiple stock_ids, and will plot the impact on the combined stocks.}
 
 \item{filters_list}{list of framrsquared filter functions to apply before plotting. Defaults to \code{list(filter_wa, filter_sport)}, which filters to WA sport fisheries.}
 
-\item{msp}{Use Model Stock Proportion? Logical, defaults to TRUE.}
+\item{msp}{Use Model Stock Proportion? Logical, defaults to TRUE. Only relevant for Chinook databases.}
+
+\item{digits_round}{How many digits should cell values be rounded to? Numeric, defaults to 1.}
+
+\item{outer_text_size}{Controls size of plot text elements except cell text. Different plot elements scale relative to this value. Numeric defaults to 18.}
+
+\item{cell_text_size}{Controls size of text size in heatmap cells.  Numeric, defaults to 5. Different units from \code{outer_text_size}.}
+
+\item{short_title}{Should the abbreviated stock name (e.g., "M-ssdnph") be used (\code{TRUE}) or the longer name (e.g., "South Puget SOund Net Pens Marked"). Logical, defaults to \code{FALSE}; \code{TRUE} may be useful when plots must be small.}
+
+\item{per_thousand_catch}{Should plot be presented in units of Impacts per Thousand Landed Catch (TRUE) or landed catch per impact (FALSE). Logical, defaults to FALSE.}
 }
 \value{
 ggplot object
 }
 \description{
 Identify how much reduction in landed catch at each fishery that would be needed
-to reduce the impacts on a focal stock by 1 fish.
+to reduce the impacts on a focal stock by 1 fish. Does not include non-retention moralities, as those can't be improved by reducing fishing in the focal species.
 }
 \examples{
 \dontrun{

--- a/man/plot_stock_mortality.Rd
+++ b/man/plot_stock_mortality.Rd
@@ -10,7 +10,8 @@ plot_stock_mortality(
   stock_id,
   top_n = 10,
   filters_list = NULL,
-  msp = TRUE
+  msp = TRUE,
+  separate_nonretention = TRUE
 )
 }
 \arguments{

--- a/man/stock_mortality.Rd
+++ b/man/stock_mortality.Rd
@@ -4,12 +4,14 @@
 \alias{stock_mortality}
 \title{Replicate Stock Mortality screen}
 \usage{
-stock_mortality(fram_db, run_id = NULL)
+stock_mortality(fram_db, run_id = NULL, stock_id = NULL)
 }
 \arguments{
 \item{fram_db}{FRAM database object}
 
-\item{run_id}{Run ID}
+\item{run_id}{atomic or vector of run_ids to filter to. Can improve speed. Optional, defaults to \code{NULL}.}
+
+\item{stock_id}{atomic or vector of stock_id to filter to. Can improve speed. Optional, defaults to \code{NULL}.}
 }
 \description{
 Returns a tibble matching the Stock Mortality screen.


### PR DESCRIPTION
Overhaul of `plot_impacts_per_catch_heatmap()` in light of identified issues, suggestions from Diego and from Ryan. Key features:

- better control of visual elements (text size, rounding, title type)
- no longer includes non-retention
- better information on categories (ids and human-readable text in all cases)
- can toggle between landed catch per impact and impacts per thousand landed catch
- accepts multiple stock IDs, which is key for some types of management (e.g. the PS sharing % for the STT process). 