### PR TITLE
updated to include non-retention

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 - fixed bug in which `fetch_table()` errored out when fetching the `Stock` or `Fishery` tables.
 - added functions to handle SONCC calculations for STT.
 - updated `compare_runs()` to apply specified tolerance to recruits as well as fishery inputs
-- Overhauled `plot_impacts_per_catch_heatmap`: no longer includes non-retention, can control more aspects of the plots (rounding, font size, abbreviated or full stock name for title), fishery labels include id numbers and timestep labels include months. Can toggle between "landed catch per impacts" (default) and "impacts per thousand landed catch". Function can now accept multiple stock ids, making it more useful for managing to objectives that are based on a sum of FRAM stocks.
+- Overhauled `plot_impacts_per_catch_heatmap`: can control more aspects of the plots (rounding, font size, abbreviated or full stock name for title), fishery labels include id numbers and timestep labels include months. Can toggle between "landed catch per impacts" (default) and "impacts per thousand landed catch". Function can now accept multiple stock ids, making it more useful for managing to objectives that are based on a sum of FRAM stocks.
 - improved speed of `stock_mortality()` and `fishery_mortality()`. Optionally accept either `stock_id` or `fishery_id` arguments which filter the fetched `mortality` function for improved speed. 
 
 # framrsquared 0.8.1

--- a/R/make_impacts_per_catch_heatmap.R
+++ b/R/make_impacts_per_catch_heatmap.R
@@ -1,7 +1,7 @@
 #' Make plots to show the amount of landed catch_per_impact
 #'
 #' Identify how much reduction in landed catch at each fishery that would be needed
-  #' to reduce the impacts on a focal stock by 1 fish. Does not include non-retention moralities, as those can't be improved by reducing fishing in the focal species.
+  #' to reduce the impacts on a focal stock by 1 fish. Does include CNR from other species, so numbers are not exact, but CNR is typically only a small fraction of total mortalities.
 #'
 #' @param fram_db fram database connection
 #' @param run_id run_id of interest
@@ -89,15 +89,14 @@ plot_impacts_per_catch_heatmap <- function(fram_db,
   if (fram_db$fram_db_species == "CHINOOK") {
     stock_mort = aeq_mortality_(fram_db, run_id = run_id, msp = msp) |>
       dplyr::filter(stock_id %in% .env$stock_id) |>
-      dplyr::mutate(total_mortality = .data$landed_catch + .data$shaker + .data$drop_off +
-                      .data$msf_landed_catch + .data$msf_shaker + .data$msf_drop_off) |>
+      add_total_mortality() |>
       dplyr::group_by(.data$fishery_id, .data$time_step) |>
       dplyr::summarize(mort = sum(.data$total_mortality)) |>
       dplyr::ungroup()
   } else{
     stock_mort = stock_mortality(fram_db, run_id = run_id, stock_id = stock_id) |>
       ## stock mortality combines msf and NS values.
-      dplyr::mutate(total_mortality = .data$landed_catch + .data$shaker + .data$drop_off) |>
+      dplyr::mutate(total_mortality = .data$landed_catch + .data$shaker + .data$drop_off + .data$non_retention) |>
       dplyr::filter(stock_id %in% .env$stock_id) |>
       dplyr::group_by(.data$fishery_id, .data$time_step) |>
       dplyr::summarize(mort = sum(.data$total_mortality)) |>

--- a/man/plot_impacts_per_catch_heatmap.Rd
+++ b/man/plot_impacts_per_catch_heatmap.Rd
@@ -43,7 +43,7 @@ ggplot object
 }
 \description{
 Identify how much reduction in landed catch at each fishery that would be needed
-to reduce the impacts on a focal stock by 1 fish. Does not include non-retention moralities, as those can't be improved by reducing fishing in the focal species.
+to reduce the impacts on a focal stock by 1 fish. Does include CNR from other species, so numbers are not exact, but CNR is typically only a small fraction of total mortalities.
 }
 \examples{
 \dontrun{

--- a/man/plot_stock_mortality.Rd
+++ b/man/plot_stock_mortality.Rd
@@ -10,8 +10,7 @@ plot_stock_mortality(
   stock_id,
   top_n = 10,
   filters_list = NULL,
-  msp = TRUE,
-  separate_nonretention = TRUE
+  msp = TRUE
 )
 }
 \arguments{


### PR DESCRIPTION
Recent changes removed non-retention mortality, with the intention of excluding non-retention due to fisheries for other species. However, this also inadvertently excluded non-retention mortality associated with MS fisheries. This merge rolls back to including all non-retention mortality. 