### PR TITLE
Update plot mortality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
     lifecycle,
     lubridate,
     odbc,
+    patchwork,
     purrr,
     readr,
     renv,

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - updated `compare_runs()` to apply specified tolerance to recruits as well as fishery inputs
 - Overhauled `plot_impacts_per_catch_heatmap`: can control more aspects of the plots (rounding, font size, abbreviated or full stock name for title), fishery labels include id numbers and timestep labels include months. Can toggle between "landed catch per impacts" (default) and "impacts per thousand landed catch". Function can now accept multiple stock ids, making it more useful for managing to objectives that are based on a sum of FRAM stocks.
 - improved speed of `stock_mortality()` and `fishery_mortality()`. Optionally accept either `stock_id` or `fishery_id` arguments which filter the fetched `mortality` function for improved speed. 
+- Updated `plot_stock_mortality()` and `plot_stock_mortality_timestep()` to account for CNR. Default behavior now
+provides the % CNR on the plot. Setting optional argument `split_cnr` to `TRUE` produces separate panels for CNR and non-CNR mortalities.
 
 # framrsquared 0.8.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 - Overhauled `plot_impacts_per_catch_heatmap`: can control more aspects of the plots (rounding, font size, abbreviated or full stock name for title), fishery labels include id numbers and timestep labels include months. Can toggle between "landed catch per impacts" (default) and "impacts per thousand landed catch". Function can now accept multiple stock ids, making it more useful for managing to objectives that are based on a sum of FRAM stocks.
 - improved speed of `stock_mortality()` and `fishery_mortality()`. Optionally accept either `stock_id` or `fishery_id` arguments which filter the fetched `mortality` function for improved speed. 
 - Updated `plot_stock_mortality()` and `plot_stock_mortality_timestep()` to account for CNR. Default behavior now
-provides the % CNR on the plot. Setting optional argument `split_cnr` to `TRUE` produces separate panels for CNR and non-CNR mortalities.
+provides the % CNR on the plot. Setting optional argument `split_cnr` to `TRUE` produces separate panels for CNR and non-CNR mortalities. Also: cosmetic changes and optional arguments to control them, support (and appropriate warnings) for taking multiple stock_id.
 
 # framrsquared 0.8.1
 

--- a/R/report_fishery_mortality.R
+++ b/R/report_fishery_mortality.R
@@ -28,11 +28,11 @@ fishery_mortality <- function(fram_db, run_id = NULL, fishery_id = NULL, msp = T
 
   fishery_mort <- fishery_mort |>
     dplyr::group_by(
-    .data$run_id,
-    .data$age,
-    .data$fishery_id,
-    .data$time_step
-  ) |>
+      .data$run_id,
+      .data$age,
+      .data$fishery_id,
+      .data$time_step
+    ) |>
     dplyr::summarize(
       dplyr::across(
         c(
@@ -83,6 +83,7 @@ fishery_mortality <- function(fram_db, run_id = NULL, fishery_id = NULL, msp = T
 #' @param top_n numeric, Number of fisheries to display
 #' @param filters_list list of framrsquared filter functions to apply before plotting.
 #' @param msp Use Model Stock Proportion? Logical, defaults to TRUE.
+#' @param split_cnr Produce separate panels for CNR and non-CNR mortality? Logical, defaults to FALSE.
 #'
 #' @seealso [plot_impacts_per_catch_heatmap()], [plot_stock_mortality_time_step()]
 #'
@@ -95,11 +96,15 @@ fishery_mortality <- function(fram_db, run_id = NULL, fishery_id = NULL, msp = T
 #'
 
 plot_stock_mortality <- function(fram_db, run_id, stock_id,
-                                 top_n = 10, filters_list = NULL, msp = TRUE){
+                                 top_n = 10,
+                                 filters_list = NULL,
+                                 msp = TRUE,
+                                 split_cnr = FALSE){
   validate_fram_db(fram_db)
   validate_run_id(fram_db, run_id)
   validate_stock_ids(fram_db, stock_id)
   validate_flag(msp)
+  validate_flag(split_cnr)
 
 
   if (length(run_id)>1) {
@@ -142,6 +147,7 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
   } else {
     mortality <- fram_db |> fetch_table_('Mortality')
   }
+
   mortality <- mortality |>
     dplyr::filter(.data$run_id == .env$run_id,
                   .data$stock_id %in% .env$stock_id) |>
@@ -149,9 +155,34 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
     dplyr::summarize(
       dplyr::across(c(.data$landed_catch:.data$drop_off,
                       .data$msf_landed_catch:.data$msf_drop_off), \(x) sum(x)),
-      .groups='drop') |>
-    add_total_mortality() |>
-    dplyr::select(.data$run_id, .data$stock_id, .data$fishery_id, total_mort = .data$total_mortality)
+      .groups='drop')
+
+  if(split_cnr){
+    mortality <- mortality |>
+      dplyr::mutate(non_cnr = .data$landed_catch +
+                      .data$shaker +
+                      .data$drop_off +
+                      .data$msf_landed_catch +
+                      .data$msf_non_retention +
+                      .data$msf_shaker +
+                      .data$msf_drop_off,
+                    cnr = .data$non_retention) |>
+      tidyr::pivot_longer(
+        cols = c("non_cnr", "cnr"),
+        names_to = "mortality_type",
+        values_to = "total_mortality"
+      )|>
+      dplyr::select(.data$run_id, .data$stock_id, .data$fishery_id, total_mort = .data$total_mortality,
+                    .data$mortality_type)
+    percent_cnr = NULL ## dummy var to avoid silly error
+  } else{
+    total_cnr = sum(mortality$non_retention)
+    mortality <- mortality |>
+      add_total_mortality() |>
+      dplyr::select(.data$run_id, .data$stock_id, .data$fishery_id, total_mort = .data$total_mortality)
+    percent_cnr = round(total_cnr / sum(mortality$total_mort)*100,
+                        1)
+  }
 
   if(!is.null(filters_list)){
     ## give species for filtering
@@ -170,17 +201,53 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
   stock_name <- stocks |>
     dplyr::filter(.data$stock_id == .env$stock_id) |>
     dplyr::pull(.data$stock_name)
-  mortality |>
+
+  if(split_cnr){
+    mortality_primary = mortality |>
+      dplyr::filter(.data$mortality_type == "non_cnr")
+  } else{
+    mortality_primary = mortality
+  }
+
+  x_max = max(mortality_primary$total_mort)
+
+  gp_final <-  gp <- mortality_primary |>
     dplyr::slice_max(.data$total_mort, n = top_n) |>
     dplyr::inner_join(fisheries, by = 'fishery_id') |>
-    ggplot2::ggplot(ggplot2::aes(.data$total_mort, stats::reorder(.data$fishery_name, .data$total_mort))) +
+    ggplot2::ggplot(ggplot2::aes(.data$total_mort,
+                                 stats::reorder(.data$fishery_name, .data$total_mort))) +
     ggplot2::geom_col() +
+    ggplot2::xlim(c(0, x_max))+
     ggplot2::labs(
-      title = glue::glue('Top mortality for stock {stock_name} (stock_id = {stock_id})'),
+      title = glue::glue('Top mortality for stock {stock_name} (stock_id = {stock_id}) | {percent_cnr}% CNR'),
       subtitle = glue::glue('{run_name} (run_id = {run_id})'),
       x = ifelse(species_used == 'COHO','Mortalities', 'AEQs (timesteps 2-4)'),
       y = 'Fishery'
     )
+
+  if(split_cnr){
+
+    gp = gp+
+      ggplot2::ggtitle(glue::glue('Top non-CNR mortality for stock {stock_name} (stock_id = {stock_id})'))
+
+    gp_cnr = mortality |>
+      dplyr::filter(.data$mortality_type == "cnr") |>
+      dplyr::slice_max(.data$total_mort, n = top_n) |>
+      dplyr::inner_join(fisheries, by = 'fishery_id') |>
+      ggplot2::ggplot(ggplot2::aes(.data$total_mort,
+                                   stats::reorder(.data$fishery_name, .data$total_mort))) +
+      ggplot2::geom_col() +
+      ## put on same scale, unless CNR is more.
+      ggplot2::xlim(c(0, x_max))+
+      ggplot2::labs(
+        title = glue::glue('Top CNR mortality'),
+        x = ifelse(species_used == 'COHO','Mortalities', 'AEQs (timesteps 2-4)'),
+        y = 'Fishery'
+      )
+    gp_final = patchwork::wrap_plots(gp, gp_cnr, ncol = 1) +
+      patchwork::plot_layout(axes = "collect")
+  }
+  return(gp_final)
 }
 
 #' Creates an ordered bar chart with

--- a/R/report_fishery_mortality.R
+++ b/R/report_fishery_mortality.R
@@ -79,11 +79,13 @@ fishery_mortality <- function(fram_db, run_id = NULL, fishery_id = NULL, msp = T
 #'
 #' @param fram_db fram database object, supplied through connect_fram_db
 #' @param run_id numeric, RunID
-#' @param stock_id numeric, ID of focal stock
+#' @param stock_id numeric, ID of focal stock. Can accept multiple ids, but this should only be used when combining FRAM stocks makes sense (e.g., combining marked and unmarked components of the same stock).
 #' @param top_n numeric, Number of fisheries to display
 #' @param filters_list list of framrsquared filter functions to apply before plotting.
 #' @param msp Use Model Stock Proportion? Logical, defaults to TRUE.
 #' @param split_cnr Produce separate panels for CNR and non-CNR mortality? Logical, defaults to FALSE.
+#' @param fishery_title_short Use abbreviated fishery names instead of full names? Useful if horizontal space is limited. Logical, defaults to FALSE.
+#' @param stock_title_short Use abbreviated stock name instead of full name in title? Will always use abbreviated stock name if multiple stock ids are provided.
 #'
 #' @seealso [plot_impacts_per_catch_heatmap()], [plot_stock_mortality_time_step()]
 #'
@@ -99,7 +101,9 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
                                  top_n = 10,
                                  filters_list = NULL,
                                  msp = TRUE,
-                                 split_cnr = FALSE){
+                                 split_cnr = FALSE,
+                                 fishery_title_short = FALSE,
+                                 stock_title_short = FALSE){
   validate_fram_db(fram_db)
   validate_run_id(fram_db, run_id)
   validate_stock_ids(fram_db, stock_id)
@@ -131,14 +135,26 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
   # lut for display of stock name
   stocks <- fram_db |>
     fetch_table_('Stock') |>
-    dplyr::filter(.data$species == fram_db$fram_db_species) |>
-    dplyr::select(.data$stock_id, .data$stock_name)
+    dplyr::filter(.data$species %in% fram_db$fram_db_species) |>
+    dplyr::select(.data$stock_id, .data$stock_name, .data$stock_long_name)
 
   # lut for display of fishery
-  fisheries <- fram_db |>
-    fetch_table_('Fishery') |>
-    dplyr::filter(.data$species == fram_db$fram_db_species) |>
-    dplyr::select(.data$fishery_id, .data$fishery_name)
+  if(fishery_title_short){
+    fisheries <- fram_db |>
+      fetch_table_('Fishery') |>
+      dplyr::filter(.data$species == fram_db$fram_db_species) |>
+      dplyr::select(.data$fishery_id,
+                    fishery_label = .data$fishery_name)
+  } else {
+    fisheries <- fram_db |>
+      fetch_table_('Fishery') |>
+      dplyr::filter(.data$species == fram_db$fram_db_species) |>
+      dplyr::select(.data$fishery_id,
+                    fishery_label = .data$fishery_title)
+  }
+
+  fisheries <- fisheries |>
+    dplyr::mutate(fishery_label = glue::glue("{fishery_label} | (id = {fishery_id})"))
 
   if(species_used == "CHINOOK"){
     mortality <- fram_db |>
@@ -151,7 +167,7 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
   mortality <- mortality |>
     dplyr::filter(.data$run_id == .env$run_id,
                   .data$stock_id %in% .env$stock_id) |>
-    dplyr::group_by(.data$run_id, .data$stock_id, .data$fishery_id) |>
+    dplyr::group_by(.data$run_id, .data$fishery_id) |>
     dplyr::summarize(
       dplyr::across(c(.data$landed_catch:.data$drop_off,
                       .data$msf_landed_catch:.data$msf_drop_off), \(x) sum(x)),
@@ -172,14 +188,14 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
         names_to = "mortality_type",
         values_to = "total_mortality"
       )|>
-      dplyr::select(.data$run_id, .data$stock_id, .data$fishery_id, total_mort = .data$total_mortality,
+      dplyr::select(.data$run_id, .data$fishery_id, total_mort = .data$total_mortality,
                     .data$mortality_type)
     percent_cnr = NULL ## dummy var to avoid silly error
   } else{
     total_cnr = sum(mortality$non_retention)
     mortality <- mortality |>
       add_total_mortality() |>
-      dplyr::select(.data$run_id, .data$stock_id, .data$fishery_id, total_mort = .data$total_mortality)
+      dplyr::select(.data$run_id, .data$fishery_id, total_mort = .data$total_mortality)
     percent_cnr = round(total_cnr / sum(mortality$total_mort)*100,
                         1)
   }
@@ -198,28 +214,39 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
     dplyr::filter(.data$run_id == .env$run_id) |>
     dplyr::pull(.data$run_name)
 
-  stock_name <- stocks |>
-    dplyr::filter(.data$stock_id == .env$stock_id) |>
-    dplyr::pull(.data$stock_name)
+  if(stock_title_short | length(stock_id) > 1){
+    stock_name <- stocks |>
+      dplyr::filter(.data$stock_id %in% .env$stock_id) |>
+      dplyr::pull(.data$stock_name)
+  } else {
+    stock_name <- stocks |>
+      dplyr::filter(.data$stock_id %in% .env$stock_id) |>
+      dplyr::pull(.data$stock_long_name)
+  }
+
+  stock_name = glue::glue_collapse(stock_name, sep = ", ")
+
 
   if(split_cnr){
     mortality_primary = mortality |>
       dplyr::filter(.data$mortality_type == "non_cnr")
+    mortality_cnr = mortality |>
+      dplyr::filter(.data$mortality_type == "cnr")
   } else{
     mortality_primary = mortality
   }
 
   x_max = max(mortality_primary$total_mort)
 
-  gp_final <-  gp <- mortality_primary |>
+  gp <- mortality_primary |>
     dplyr::slice_max(.data$total_mort, n = top_n) |>
     dplyr::inner_join(fisheries, by = 'fishery_id') |>
     ggplot2::ggplot(ggplot2::aes(.data$total_mort,
-                                 stats::reorder(.data$fishery_name, .data$total_mort))) +
+                                 stats::reorder(.data$fishery_label, .data$total_mort))) +
     ggplot2::geom_col() +
     ggplot2::xlim(c(0, x_max))+
     ggplot2::labs(
-      title = glue::glue('Top mortality for stock {stock_name} (stock_id = {stock_id}) | {percent_cnr}% CNR'),
+      title = glue::glue('Top mortality for stock {stock_name} (stock_id = {glue::glue_collapse(stock_id, ", ")}) | {percent_cnr}% CNR'),
       subtitle = glue::glue('{run_name} (run_id = {run_id})'),
       x = ifelse(species_used == 'COHO','Mortalities', 'AEQs (timesteps 2-4)'),
       y = 'Fishery'
@@ -228,14 +255,13 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
   if(split_cnr){
 
     gp = gp+
-      ggplot2::ggtitle(glue::glue('Top non-CNR mortality for stock {stock_name} (stock_id = {stock_id})'))
+      ggplot2::ggtitle(glue::glue('Top non-CNR mortality for stock {stock_name} (stock_id = {glue::glue_collapse(stock_id, ", ")})'))
 
-    gp_cnr = mortality |>
-      dplyr::filter(.data$mortality_type == "cnr") |>
+    gp_cnr = mortality_cnr |>
       dplyr::slice_max(.data$total_mort, n = top_n) |>
       dplyr::inner_join(fisheries, by = 'fishery_id') |>
       ggplot2::ggplot(ggplot2::aes(.data$total_mort,
-                                   stats::reorder(.data$fishery_name, .data$total_mort))) +
+                                   stats::reorder(.data$fishery_label, .data$total_mort))) +
       ggplot2::geom_col() +
       ## put on same scale, unless CNR is more.
       ggplot2::xlim(c(0, x_max))+
@@ -246,9 +272,27 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
       )
     gp_final = patchwork::wrap_plots(gp, gp_cnr, ncol = 1) +
       patchwork::plot_layout(axes = "collect")
+  } else {
+    gp_final = gp
   }
+
   return(gp_final)
 }
+
+
+
+
+label_timesteps = function(.data, fram_db){
+  time_step_lut = fram_db |>
+    fetch_table_("TimeStep") |>
+    dplyr::mutate(time_step_label = as.factor(glue::glue("{time_step_id} ({time_step_name})"))) |>
+    dplyr::select(time_step = .data$time_step_id,
+                  .data$time_step_label)
+  .data |>
+    dplyr::left_join(time_step_lut,
+              by = "time_step")
+}
+
 
 #' Creates an ordered bar chart with
 #' the top number of mortalities per
@@ -266,7 +310,15 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
 #' }
 #'
 
-plot_stock_mortality_time_step <- function(fram_db, run_id, stock_id, top_n = 10, filters_list = NULL, msp = TRUE){
+plot_stock_mortality_time_step <- function(fram_db,
+                                           run_id,
+                                           stock_id,
+                                           top_n = 10,
+                                           filters_list = NULL,
+                                           msp = TRUE,
+                                           split_cnr = FALSE,
+                                           fishery_title_short = FALSE,
+                                           stock_title_short = FALSE){
   validate_fram_db(fram_db)
   validate_run_id(fram_db, run_id)
   validate_stock_ids(fram_db, stock_id)
@@ -274,7 +326,7 @@ plot_stock_mortality_time_step <- function(fram_db, run_id, stock_id, top_n = 10
 
 
   if (length(run_id)>1) {
-    cli::cli_abort("Plot is not meaningful when combining multiple runs. Provide a single run in run_id.")
+    cli::cli_alert_warning("Plot is not meaningful when combining multiple runs. Provide a single run in run_id.")
   }
 
   # make sure run ids are integers
@@ -297,19 +349,34 @@ plot_stock_mortality_time_step <- function(fram_db, run_id, stock_id, top_n = 10
   stocks <- fram_db |>
     fetch_table_('Stock') |>
     dplyr::filter(.data$species == fram_db$fram_db_species) |>
-    dplyr::select(.data$stock_id, .data$stock_name)
+    dplyr::select(.data$stock_id, .data$stock_name, .data$stock_long_name)
 
   # lut for display of fishery
-  fisheries <- fram_db |>
-    fetch_table_('Fishery') |>
-    dplyr::filter(.data$species == fram_db$fram_db_species) |>
-    dplyr::select(.data$fishery_id, .data$fishery_name)
+  if(fishery_title_short){
+    fisheries <- fram_db |>
+      fetch_table_('Fishery') |>
+      dplyr::filter(.data$species == fram_db$fram_db_species) |>
+      dplyr::select(.data$fishery_id,
+                    fishery_label = .data$fishery_name)
+  } else {
+    fisheries <- fram_db |>
+      fetch_table_('Fishery') |>
+      dplyr::filter(.data$species == fram_db$fram_db_species) |>
+      dplyr::select(.data$fishery_id,
+                    fishery_label = .data$fishery_title)
+  }
+
+  fisheries <- fisheries |>
+    dplyr::mutate(fishery_label = glue::glue("{fishery_label} | (id = {fishery_id})"))
+
 
   if(fram_db$fram_db_species == "CHINOOK"){
-    mortality <- fram_db |> aeq_mortality_(msp = msp)
+    mortality <- fram_db |> aeq_mortality_(msp = msp)|>
+      dplyr::filter(.data$time_step != 1)
   } else {
     mortality <- fram_db |> fetch_table_('Mortality')
   }
+
   mortality <- mortality |>
     dplyr::filter(.data$run_id == .env$run_id,
                   .data$stock_id %in% .env$stock_id) |>
@@ -317,12 +384,36 @@ plot_stock_mortality_time_step <- function(fram_db, run_id, stock_id, top_n = 10
     dplyr::summarize(
       dplyr::across(c(.data$landed_catch:.data$drop_off,
                       .data$msf_landed_catch:.data$msf_drop_off), \(x) sum(x)),
-      .groups='drop') |>
-    dplyr::mutate(
-      total_mort = .data$landed_catch + .data$non_retention + .data$shaker + .data$drop_off +
-        .data$msf_landed_catch + .data$msf_non_retention + .data$msf_shaker + .data$msf_drop_off
-    ) |>
-    dplyr::select(.data$run_id, .data$fishery_id, .data$total_mort, .data$time_step)
+      .groups='drop')
+
+  if(split_cnr){
+    mortality <- mortality |>
+      dplyr::mutate(non_cnr = .data$landed_catch +
+                      .data$shaker +
+                      .data$drop_off +
+                      .data$msf_landed_catch +
+                      .data$msf_non_retention +
+                      .data$msf_shaker +
+                      .data$msf_drop_off,
+                    cnr = .data$non_retention) |>
+      tidyr::pivot_longer(
+        cols = c("non_cnr", "cnr"),
+        names_to = "mortality_type",
+        values_to = "total_mortality"
+      )|>
+      dplyr::select(.data$run_id, .data$fishery_id, total_mort = .data$total_mortality,
+                    .data$mortality_type,
+                    .data$time_step)
+    percent_cnr = NULL ## dummy var to avoid silly error
+  } else{
+    total_cnr = sum(mortality$non_retention)
+    mortality <- mortality |>
+      add_total_mortality() |>
+      dplyr::select(.data$run_id, .data$fishery_id, total_mort = .data$total_mortality,
+                    .data$time_step)
+    percent_cnr = round(total_cnr / sum(mortality$total_mort)*100,
+                        1)
+  }
 
   if(!is.null(filters_list)){
     ## give species for filtering
@@ -333,45 +424,118 @@ plot_stock_mortality_time_step <- function(fram_db, run_id, stock_id, top_n = 10
     }
   }
 
+  mortality = mortality |>
+    label_timesteps(fram_db = fram_db)
+
+
   run_name <- fram_db |>
     fetch_table_('RunID') |>
     dplyr::filter(.data$run_id == .env$run_id) |>
     dplyr::pull(.data$run_name)
 
-  stock_name <- stocks |>
-    dplyr::filter(.data$stock_id %in% .env$stock_id) |>
-    dplyr::pull(.data$stock_name)
+  if(stock_title_short | length(stock_id) > 1){
+    stock_name <- stocks |>
+      dplyr::filter(.data$stock_id %in% .env$stock_id) |>
+      dplyr::pull(.data$stock_name)
+  } else {
+    stock_name <- stocks |>
+      dplyr::filter(.data$stock_id %in% .env$stock_id) |>
+      dplyr::pull(.data$stock_long_name)
+  }
 
   stock_name <- paste0(stock_name, collapse = ', ')
 
-  mort_table <- mortality |>
+
+  if(split_cnr){
+    mortality_primary = mortality |>
+      dplyr::filter(.data$mortality_type == "non_cnr")
+    mortality_cnr = mortality |>
+      dplyr::filter(.data$mortality_type == "cnr")
+  } else{
+    mortality_primary = mortality
+  }
+
+  ## primary
+
+  mort_table <- mortality_primary |>
     dplyr::group_by(.data$run_id, .data$fishery_id) |>
     dplyr::summarize(
       dplyr::across(.data$total_mort, \(x) sum(x)),
       .groups='drop') |>
-    dplyr::slice_max(.data$total_mort, n = top_n) |>
-    dplyr::pull(.data$fishery_id)
+    # dplyr::ungroup()
+    dplyr::slice_max(.data$total_mort, n = top_n)
 
-  top_fish <- mortality |>
-    dplyr::filter(.data$fishery_id %in% mort_table)
+  x_max = max(mort_table$total_mort)
+
+  top_fish <- mortality_primary |>
+    dplyr::filter(.data$fishery_id %in% mort_table$fishery_id)
 
 
-  top_fish |>
+  gp <- top_fish |>
     dplyr::inner_join(fisheries, by = 'fishery_id') |>
     ggplot2::ggplot(ggplot2::aes(
       .data$total_mort,
-      stats::reorder(.data$fishery_name, .data$total_mort, function(x) {
+      stats::reorder(.data$fishery_label, .data$total_mort, function(x) {
         sum(x)
       }),
-      fill = factor(.data$time_step)
-    )) +
+      fill = .data$time_step_label)
+    ) +
     ggplot2::geom_col(alpha = .6) +
     ggplot2::scale_fill_brewer(palette = 'Set1') +
+    ggplot2::xlim(c(0, x_max))+
     ggplot2::labs(
-      title = glue::glue('Top mortality for stock {stock_name} (stock_id = {stock_id})'),
+      title = glue::glue('Top mortality for stock {stock_name} (stock_id = {glue::glue_collapse(stock_id, ", ")}) | {percent_cnr}% CNR'),
       subtitle = glue::glue('{run_name} (run_id = {run_id})'),
-      x = 'Mortalities',
-      y = 'Fishery'
+      x = ifelse(species_used == 'COHO','Mortalities', 'AEQs'),
+      y = 'Fishery',
+      fill = "Timestep"
     ) +
-    ggplot2::theme(legend.title = ggplot2::element_blank())
+    ggplot2::theme(legend.position = "top")
+
+
+  if(split_cnr){
+
+    gp = gp+
+      ggplot2::ggtitle(glue::glue('Top non-CNR mortality for stock {stock_name} (stock_id = {glue::glue_collapse(stock_id, ", ")})'))
+
+    mort_table <- mortality_cnr |>
+      dplyr::group_by(.data$run_id, .data$fishery_id) |>
+      dplyr::summarize(
+        dplyr::across(.data$total_mort, \(x) sum(x)),
+        .groups='drop') |>
+      dplyr::slice_max(.data$total_mort, n = top_n) |>
+      dplyr::pull(.data$fishery_id)
+
+    top_fish <- mortality_cnr |>
+      dplyr::filter(.data$fishery_id %in% mort_table)
+
+
+    gp_cnr <- top_fish |>
+      dplyr::inner_join(fisheries, by = 'fishery_id') |>
+      ggplot2::ggplot(ggplot2::aes(
+        .data$total_mort,
+        stats::reorder(.data$fishery_label, .data$total_mort, function(x) {
+          sum(x)
+        }),
+        fill = .data$time_step_label
+      )) +
+      ggplot2::geom_col(alpha = .6) +
+      ggplot2::scale_fill_brewer(palette = 'Set1') +
+      ggplot2::xlim(c(0, x_max))+
+      ggplot2::labs(
+        title = glue::glue('Top CNR mortality'),
+        subtitle = glue::glue('{run_name} (run_id = {run_id})'),
+        x = ifelse(species_used == 'COHO','Mortalities', 'AEQs'),
+        y = 'Fishery'
+      ) +
+      ggplot2::theme(legend.title = ggplot2::element_blank(),
+                     legend.position = "none")
+
+    gp_final = patchwork::wrap_plots(gp, gp_cnr, ncol = 1) +
+      patchwork::plot_layout(axes = "collect")
+
+  }  else  {
+    gp_final = gp
+  }
+  return(gp_final)
 }

--- a/man/plot_stock_mortality.Rd
+++ b/man/plot_stock_mortality.Rd
@@ -10,7 +10,8 @@ plot_stock_mortality(
   stock_id,
   top_n = 10,
   filters_list = NULL,
-  msp = TRUE
+  msp = TRUE,
+  split_cnr = FALSE
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ plot_stock_mortality(
 \item{filters_list}{list of framrsquared filter functions to apply before plotting.}
 
 \item{msp}{Use Model Stock Proportion? Logical, defaults to TRUE.}
+
+\item{split_cnr}{Produce separate panels for CNR and non-CNR mortality? Logical, defaults to FALSE.}
 }
 \description{
 Creates an ordered bar chart with

--- a/man/plot_stock_mortality.Rd
+++ b/man/plot_stock_mortality.Rd
@@ -11,7 +11,9 @@ plot_stock_mortality(
   top_n = 10,
   filters_list = NULL,
   msp = TRUE,
-  split_cnr = FALSE
+  split_cnr = FALSE,
+  fishery_title_short = FALSE,
+  stock_title_short = FALSE
 )
 }
 \arguments{
@@ -19,7 +21,7 @@ plot_stock_mortality(
 
 \item{run_id}{numeric, RunID}
 
-\item{stock_id}{numeric, ID of focal stock}
+\item{stock_id}{numeric, ID of focal stock. Can accept multiple ids, but this should only be used when combining FRAM stocks makes sense (e.g., combining marked and unmarked components of the same stock).}
 
 \item{top_n}{numeric, Number of fisheries to display}
 
@@ -28,6 +30,10 @@ plot_stock_mortality(
 \item{msp}{Use Model Stock Proportion? Logical, defaults to TRUE.}
 
 \item{split_cnr}{Produce separate panels for CNR and non-CNR mortality? Logical, defaults to FALSE.}
+
+\item{fishery_title_short}{Use abbreviated fishery names instead of full names? Useful if horizontal space is limited. Logical, defaults to FALSE.}
+
+\item{stock_title_short}{Use abbreviated stock name instead of full name in title? Will always use abbreviated stock name if multiple stock ids are provided.}
 }
 \description{
 Creates an ordered bar chart with

--- a/man/plot_stock_mortality_time_step.Rd
+++ b/man/plot_stock_mortality_time_step.Rd
@@ -12,7 +12,10 @@ plot_stock_mortality_time_step(
   stock_id,
   top_n = 10,
   filters_list = NULL,
-  msp = TRUE
+  msp = TRUE,
+  split_cnr = FALSE,
+  fishery_title_short = FALSE,
+  stock_title_short = FALSE
 )
 }
 \arguments{
@@ -20,13 +23,19 @@ plot_stock_mortality_time_step(
 
 \item{run_id}{numeric, RunID}
 
-\item{stock_id}{numeric, ID of focal stock}
+\item{stock_id}{numeric, ID of focal stock. Can accept multiple ids, but this should only be used when combining FRAM stocks makes sense (e.g., combining marked and unmarked components of the same stock).}
 
 \item{top_n}{numeric, Number of fisheries to display}
 
 \item{filters_list}{list of framrsquared filter functions to apply before plotting.}
 
 \item{msp}{Use Model Stock Proportion? Logical, defaults to TRUE.}
+
+\item{split_cnr}{Produce separate panels for CNR and non-CNR mortality? Logical, defaults to FALSE.}
+
+\item{fishery_title_short}{Use abbreviated fishery names instead of full names? Useful if horizontal space is limited. Logical, defaults to FALSE.}
+
+\item{stock_title_short}{Use abbreviated stock name instead of full name in title? Will always use abbreviated stock name if multiple stock ids are provided.}
 }
 \description{
 Creates an ordered bar chart with


### PR DESCRIPTION
Updated plot_stock_mortality() and plot_stock_mortality_time_step():

- cosmetic changes to improve readability
- control of cosmetic changes: can choose to revert to the shorter stock and fishery labeling with optional arguments
- option to plot CNR and non-CNR in separate panels
- support to combine multiple stocks, with appropriate warnings not to unless you know what you're doing. Presumed use-case: understanding the total mortality for a stock that FRAM splits into marked and unmarked components.