### PR TITLE
relabel "aeq" column as "aeq_constant"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # framrsquared (development version)
 
+- fixe bug in which `copy_runs()` did not correctly copy entries of "SLRatio" table for Chinook. 
 - fixed bug in which `fetch_table()` errored out when fetching the `Stock` or `Fishery` tables.
 - added functions to handle SONCC calculations for STT.
 - updated `compare_runs()` to apply specified tolerance to recruits as well as fishery inputs, compare SLRatio table (Chinook only), and add option to save output to text file instead of console, and invisibly returns list of the comparison dataframes. `compare_sl_ratio()` handles the sublegal ratio comparisons.
@@ -9,7 +10,7 @@
 provides the % CNR on the plot. Setting optional argument `split_cnr` to `TRUE` produces separate panels for CNR and non-CNR mortalities. Also: cosmetic changes and optional arguments to control them, support (and appropriate warnings) for taking multiple stock_id. `warn` and `verbose` arguments control printing of informative messages in the console.
 - filter functions now have optional argument `return_ids` -- when set to `TRUE`, functions return the fishery (or stock) ids used to filter rather than the filtered dataframe. Useful for double-checking things, creating "union filters" and for planned future work.
 - new filter functions added: `filter_stt()` and `filter_stt_nt()` for STT Coho stocks; `filter_hatchery()`, `filter_wild()`, `filter_mixed()` for coho stocks.
-- BUG FIX: `copy_runs()` now correctly copies entries of "SLRatio" table for Chinook. 
+- updated 
 
 # framrsquared 0.8.1
 

--- a/R/aeq_mortality.R
+++ b/R/aeq_mortality.R
@@ -77,7 +77,8 @@ aeq_mortality <- function(fram_db, run_id = NULL, msp = TRUE, label = TRUE) {
     dplyr::arrange(.data$run_id, .data$fishery_id,
                    .data$time_step, .data$stock_id
     ) |>
-    `attr<-`('species', fram_db$fram_db_species)
+    `attr<-`('species', fram_db$fram_db_species) |>
+    dplyr::rename("aeq_constant" = "aeq")
   if(label == TRUE){
     aeq_m <- aeq_m |>
       framrosetta::label_fisheries() |>


### PR DESCRIPTION
Addressing #125. `aeq_mortality()` function leaves a column, previously labeled "aeq", which contains the stock x age AEQ constant used to translate raw numbers into AEQs. However, the label was easy to misinterpret as supposedly containing the total AEQ mortalities, leading to confusion.

The column has been relabeled to "aeq_constant". 