### PR TITLE
using && to force sequential checks of is.null and other conditions

### DIFF
--- a/R/msp_mortality.R
+++ b/R/msp_mortality.R
@@ -32,7 +32,7 @@ msp_mortality = function(fram_db, run_id = NULL){
     dplyr::inner_join(msp, by = 'base_period_id', relationship = 'many-to-many') |>
     dplyr::select(.data$run_id, .data$fishery_id, .data$model_stock_proportion)
 
-  if(!is.null(run_id) &
+  if(!is.null(run_id) &&
      run_id %in% msp_run_id$run_id &
      !(run_id %in% unique(mortality$run_id))){
     cli::cli_abort("Run_id must be represented in Mortality table. Has this FRAM run been run? Run IDs available: {.val {unique(mortality$run_id)}}.")

--- a/R/msp_mortality.R
+++ b/R/msp_mortality.R
@@ -33,7 +33,7 @@ msp_mortality = function(fram_db, run_id = NULL){
     dplyr::select(.data$run_id, .data$fishery_id, .data$model_stock_proportion)
 
   if(!is.null(run_id) &&
-     run_id %in% msp_run_id$run_id &
+     run_id %in% msp_run_id$run_id &&
      !(run_id %in% unique(mortality$run_id))){
     cli::cli_abort("Run_id must be represented in Mortality table. Has this FRAM run been run? Run IDs available: {.val {unique(mortality$run_id)}}.")
   }

--- a/R/report_fishery_mortality.R
+++ b/R/report_fishery_mortality.R
@@ -122,10 +122,10 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
     cli::cli_alert_warning("Plot may not be meaningful when combining stock (unless combined FRAM stocks have biological interpretation). Consider providing a single value for stock_id.")
   }
 
-  if(!is.null(filters_list) & !is.list(filters_list)){
+  if(!is.null(filters_list) && !is.list(filters_list)){
     cli::cli_abort("If provided, filters_list must be a list of fishery filter functions.")
   }
-  if(!is.null(filters_list) & !all(purrr::map_vec(filters_list, \(x) is.function(x)))){
+  if(!is.null(filters_list) && !all(purrr::map_vec(filters_list, \(x) is.function(x)))){
     cli::cli_abort("If provided, filters_list must be a list of fishery filter functions. One or more list items is not a function.")
   }
   validate_flag(warn)
@@ -339,10 +339,10 @@ plot_stock_mortality_time_step <- function(fram_db,
     cli::cli_alert_warning("Plot may not be meaningful when combining stock (unless combined FRAM stocks have biological interpretation). Consider providing a single value for stock_id.")
   }
 
-  if(!is.null(filters_list) & !is.list(filters_list)){
+  if(!is.null(filters_list) && !is.list(filters_list)){
     cli::cli_abort("If provided, filters_list must be a list of fishery filter functions.")
   }
-  if(!is.null(filters_list) & !all(purrr::map_vec(filters_list, \(x) is.function(x)))){
+  if(!is.null(filters_list) && !all(purrr::map_vec(filters_list, \(x) is.function(x)))){
     cli::cli_abort("If provided, filters_list must be a list of fishery filter functions. One or more list items is not a function.")
   }
 


### PR DESCRIPTION
Fixed bug introduced in safety checks of msp_mortality, which propagated up to our plotting functions. 
Basic version of the bug is that the following errors out:

```r 
temp = NULL
if(!is.null(temp) & temp > 0) { print("temp is positive")}
```

solution is to replace the & with &&. Did so in msp_mortality, also two similar safety checks in `report_fishery_mortality()`.
