### PR TITLE
Added helper functions and skip_if_no_test_db

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@ provides the % CNR on the plot. Setting optional argument `split_cnr` to `TRUE` 
 - new filter functions added: `filter_stt()` and `filter_stt_nt()` for STT Coho stocks; `filter_hatchery()`, `filter_wild()`, `filter_mixed()` for coho stocks.
 - Added `filter_nr_flags()` to apply NAs to non-retention dataframes based on the non_retention_flag column. Analogous to `filter_flags()`
 - Added `check_bp_coverage()`, which identifies if fishery inputs or CNR inputs contain fishery x time steps that are not represented in the base period. This is now called in compare_runs()
+- Added better testing framework, linked to external testing database directory. Only affects developers who want to run the unit tests -- see the "Contribute" section of Readme for details on setup. Convenience connection functions are included in `tests/testthat/helper-dir.R", but will only work if the testing database directory is set up. 
 
 # framrsquared 0.8.1
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ To install the development version, which may include new features that have bee
 ```r
 pak::pkg_install("FRAMverse/framrsquared@dev")
 ```
+
+
+## Contributing
+
+To support unit tests while maintaining the privacy of parts of the databases, we have set up an optional unit testing procedure. If you want to be able to run the tests during development, contact Collin Edwards to get a zip file containing databases used for testing (pre, post, and transfer databases for Chinook and Coho, as well as several "broken" databases that test framrsquared error handling). The unit tests skip unless  there is a environmental variable `FRAMRSQURED_TEST_DIR`, which should point to your local copy of this test directory (unzipped). 
+
+In addition to enabling the unit tests, setting up the test directory and associated environmental variable will enable a collection of internal `connection_*` functions (defined in `tests/testthat/helper-dir.R`) to quickly make read-only connections with fram databases for ad-hoc testing and development.

--- a/tests/testthat/helper-dir.R
+++ b/tests/testthat/helper-dir.R
@@ -1,0 +1,69 @@
+db_test_path <- function(...) {
+  path <- Sys.getenv("FRAMRSQURED_TEST_DIR", unset = NA)
+  if (is.na(path)) return(NA_character_)
+  file.path(path, ...)
+}
+
+skip_if_no_test_db <- function() {
+  path <- db_test_path()
+  if (is.na(path) || !file.exists(path)) {
+    testthat::skip("Test database not available")
+  }
+}
+
+## helper functions to make it easy to do ad-hoc tests
+
+connection_coho_pre <- function(){
+  path <- db_test_path()
+  if (is.na(path) || !file.exists(path)) {
+    cli::cli_abort("Test database not available")
+  } else {
+    return(connect_fram_db(paste0(path, "/original_databases/coho_pre.mdb"), read_only = TRUE))
+  }
+}
+
+connection_coho_post <- function(){
+  path <- db_test_path()
+  if (is.na(path) || !file.exists(path)) {
+    cli::cli_abort("Test database not available")
+  } else {
+    return(connect_fram_db(paste0(path, "/original_databases/coho_post.mdb"), read_only = TRUE))
+  }
+}
+
+connection_coho_transfer <- function(){
+  path <- db_test_path()
+  if (is.na(path) || !file.exists(path)) {
+    cli::cli_abort("Test database not available")
+  } else {
+    return(connect_fram_db(paste0(path, "/original_databases/coho_transfer.mdb"), read_only = TRUE))
+  }
+}
+
+
+connection_chin_pre <- function(){
+  path <- db_test_path()
+  if (is.na(path) || !file.exists(path)) {
+    cli::cli_abort("Test database not available")
+  } else {
+    return(connect_fram_db(paste0(path, "/original_databases/chin_pre.mdb"), read_only = TRUE))
+  }
+}
+
+connection_chin_post <- function(){
+  path <- db_test_path()
+  if (is.na(path) || !file.exists(path)) {
+    cli::cli_abort("Test database not available")
+  } else {
+    return(connect_fram_db(paste0(path, "/original_databases/chin_post.mdb"), read_only = TRUE))
+  }
+}
+
+connection_chin_transfer <- function(){
+  path <- db_test_path()
+  if (is.na(path) || !file.exists(path)) {
+    cli::cli_abort("Test database not available")
+  } else {
+    return(connect_fram_db(paste0(path, "/original_databases/chin_transfer.mdb"), read_only = TRUE))
+  }
+}

--- a/tests/testthat/helper-dir.R
+++ b/tests/testthat/helper-dir.R
@@ -1,5 +1,5 @@
 db_test_path <- function(...) {
-  path <- Sys.getenv("FRAMRSQURED_TEST_DIR", unset = NA)
+  path <- Sys.getenv("FRAMRSQUARED_TEST_DIR", unset = NA)
   if (is.na(path)) return(NA_character_)
   file.path(path, ...)
 }
@@ -7,7 +7,7 @@ db_test_path <- function(...) {
 skip_if_no_test_db <- function() {
   path <- db_test_path()
   if (is.na(path) || !file.exists(path)) {
-    testthat::skip("Test database not available")
+    testthat::skip("Test database not available, and/or FRAMRSQUARED_TEST_DIR environmental variable not defined.")
   }
 }
 
@@ -16,7 +16,7 @@ skip_if_no_test_db <- function() {
 connection_coho_pre <- function(){
   path <- db_test_path()
   if (is.na(path) || !file.exists(path)) {
-    cli::cli_abort("Test database not available")
+    cli::cli_abort("Test database not available, and/or FRAMRSQUARED_TEST_DIR environmental variable not defined.")
   } else {
     return(connect_fram_db(paste0(path, "/original_databases/coho_pre.mdb"), read_only = TRUE))
   }
@@ -25,7 +25,7 @@ connection_coho_pre <- function(){
 connection_coho_post <- function(){
   path <- db_test_path()
   if (is.na(path) || !file.exists(path)) {
-    cli::cli_abort("Test database not available")
+    cli::cli_abort("Test database not available, and/or FRAMRSQUARED_TEST_DIR environmental variable not defined.")
   } else {
     return(connect_fram_db(paste0(path, "/original_databases/coho_post.mdb"), read_only = TRUE))
   }
@@ -34,7 +34,7 @@ connection_coho_post <- function(){
 connection_coho_transfer <- function(){
   path <- db_test_path()
   if (is.na(path) || !file.exists(path)) {
-    cli::cli_abort("Test database not available")
+    cli::cli_abort("Test database not available, and/or FRAMRSQUARED_TEST_DIR environmental variable not defined.")
   } else {
     return(connect_fram_db(paste0(path, "/original_databases/coho_transfer.mdb"), read_only = TRUE))
   }
@@ -44,7 +44,7 @@ connection_coho_transfer <- function(){
 connection_chin_pre <- function(){
   path <- db_test_path()
   if (is.na(path) || !file.exists(path)) {
-    cli::cli_abort("Test database not available")
+    cli::cli_abort("Test database not available, and/or FRAMRSQUARED_TEST_DIR environmental variable not defined.")
   } else {
     return(connect_fram_db(paste0(path, "/original_databases/chin_pre.mdb"), read_only = TRUE))
   }
@@ -53,7 +53,7 @@ connection_chin_pre <- function(){
 connection_chin_post <- function(){
   path <- db_test_path()
   if (is.na(path) || !file.exists(path)) {
-    cli::cli_abort("Test database not available")
+    cli::cli_abort("Test database not available, and/or FRAMRSQUARED_TEST_DIR environmental variable not defined.")
   } else {
     return(connect_fram_db(paste0(path, "/original_databases/chin_post.mdb"), read_only = TRUE))
   }
@@ -62,7 +62,7 @@ connection_chin_post <- function(){
 connection_chin_transfer <- function(){
   path <- db_test_path()
   if (is.na(path) || !file.exists(path)) {
-    cli::cli_abort("Test database not available")
+    cli::cli_abort("Test database not available, and/or FRAMRSQUARED_TEST_DIR environmental variable not defined.")
   } else {
     return(connect_fram_db(paste0(path, "/original_databases/chin_transfer.mdb"), read_only = TRUE))
   }

--- a/tests/testthat/test-fetch_data.R
+++ b/tests/testthat/test-fetch_data.R
@@ -1,0 +1,7 @@
+test_that("fetch_table basics", {
+  skip_if_no_test_db()
+  db <- connection_chin_post()
+  expect_no_error(fetch_table(db, "Stock"))
+  expect_error(fetch_table(db, "stock"))
+  disconnect_fram_db(db)
+})


### PR DESCRIPTION
- Added internal `skip_if_no_test_db()` and `db_test_path()` functions to support unit testing
- added connection_*_*() functions (chin / coho x pre/post/transfer) to quickly make connections to appropriate databases in the test directory. The resulting connections are read only (we don't want to contaminate test directories).

Taking advantages of these changes requires (a) getting the test database directory from Collin, and (b) adding a `FRAMRSQUARED_TEST_DIR` variable to your .Renviron that is the file path for the directory.