### PR TITLE
Reducing package dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,15 +23,11 @@ Imports:
     framrosetta (>= 0.1.0),
     ggplot2,
     glue,
-    here,
     janitor,
     lifecycle,
     lubridate,
     odbc,
-    patchwork,
     purrr,
-    readr,
-    renv,
     rlang,
     RSQLite,
     scales,
@@ -44,12 +40,15 @@ Depends:
     R (>= 4.1)
 Suggests: 
     evaluate,
+    here,
     knitr,
-    testthat (>= 3.0.0),
-    rmarkdown,
     openxlsx2,
-    withr,
-    vdiffr
+    patchwork,
+    renv,
+    rmarkdown,
+    testthat (>= 3.0.0),
+    vdiffr,
+    withr
 VignetteBuilder:
   knitr
 Config/testthat/edition: 3

--- a/R/initialize_project.R
+++ b/R/initialize_project.R
@@ -44,6 +44,7 @@ initialize_project <-  function(
     template_overwrite = TRUE,
     color = "coffee",
     quiet = TRUE) {
+
   validate_character(folders)
   validate_flag(quarto)
   organization  <- rlang::arg_match(organization)
@@ -51,6 +52,9 @@ initialize_project <-  function(
   validate_flag(template_overwrite)
   validate_character(color, n = 1)
   validate_flag(quiet)
+
+  rlang::check_installed("here")
+  rlang::check_installed("renv")
 
   purrr::walk(folders,
               \(folder) dir.create(here::here(glue::glue("{folder}")), recursive = TRUE))

--- a/R/report_fishery_mortality.R
+++ b/R/report_fishery_mortality.R
@@ -125,6 +125,8 @@ plot_stock_mortality <- function(fram_db, run_id, stock_id,
   validate_flag(msp)
   validate_flag(split_cnr)
 
+  rlang::check_installed("patchwork")
+
   # make sure run ids are integers
   if (length(stock_id)>1 & warn) {
     cli::cli_alert_warning("Plot may not be meaningful when combining stock (unless combined FRAM stocks have biological interpretation). Consider providing a single value for stock_id.")
@@ -328,6 +330,7 @@ plot_stock_mortality_time_step <- function(fram_db,
   validate_stock_ids(fram_db, stock_id)
   validate_flag(msp)
 
+  rlang::check_installed("patchwork")
 
   if (length(run_id)>1) {
     cli::cli_alert_warning("Plot is not meaningful when combining multiple runs. Provide a single run in run_id.")

--- a/R/sensitivity.R
+++ b/R/sensitivity.R
@@ -145,7 +145,7 @@ sensitivity_scaled <- function(fram_db,
   if (save_log) {
     db_path <- dirname(fram_db$fram_db_connection@info$dbname)
     log_name <- get_unique_filename(paste0(db_path, "/sensitivity_log - ", label, ".csv"))
-    readr::write_csv(df, file = log_name)
+    utils::write.csv(df, file = log_name, row.names = FALSE)
     cli::cli_alert_success("Log for run: {log_name}.")
   }
   cli::cli_alert_success("Successfully generated sensitivity analyses!")
@@ -297,7 +297,7 @@ sensitivity_exact <- function(fram_db,
   if (save_log) {
     db_path <- dirname(fram_db$fram_db_connection@info$dbname)
     log_name <- get_unique_filename(paste0(db_path, "/sensitivity_log - ", label, ".csv"))
-    readr::write_csv(replace_df, file = log_name)
+    utils::write.csv(replace_df, file = log_name, row.names = FALSE)
     cli::cli_alert_success("Log for run: {log_name}.")
   }
 }


### PR DESCRIPTION
- readr was only used for read_csv() in a few places. Replaced with `utils::read.csv() with `row.names = FALSE`. 
- here and renv were only used for `initialize_project()`, and renv is only used for an option there. Both are moved to suggests, with `rlang::check_package()`.
- patchwork is only used for plotting in `report_fishery_mortality.R`. Moved to Suggests, has `rlang::check_package()` where appropriate.

Resolves #192 